### PR TITLE
Correct iOS flash when changing date

### DIFF
--- a/lib/datepicker/DatePickerDialog.ios.js
+++ b/lib/datepicker/DatePickerDialog.ios.js
@@ -13,6 +13,9 @@ export default class DatePickerDialog extends Component{
 
   constructor(props){
     super(props);
+
+	this.modalKey = `IosDatePickerModal_${Date.now()}`
+
     this.state = {
       datePickerVisible: false,
       options: null
@@ -100,7 +103,7 @@ export default class DatePickerDialog extends Component{
     }
 
     return(
-      <Modal style={{flex:1}} onRequestClose={() => {}} visible={this.state.datePickerVisible} transparent key={`IosDatePickerModal_${Date.now()}`}>
+      <Modal style={{flex:1}} onRequestClose={() => {}} visible={this.state.datePickerVisible} transparent key={this.modalKey}>
         <View style={styles.container} >
           <View style={styles.background}>
             <View style={{flexDirection:'row'}}>


### PR DESCRIPTION
On iOS, the screen was flashing when changing the selected date.

This was, most likely, caused by the render function that was creating a Modal with a new key each time it was called. The pull-request simply made the Modal's key unique per instance.


Corrects issue https://github.com/pandiaraj44/react-native-datepicker-dialog/issues/4