### PR TITLE
Update DatePickerDialog.ios.js

### DIFF
--- a/lib/datepicker/DatePickerDialog.ios.js
+++ b/lib/datepicker/DatePickerDialog.ios.js
@@ -121,10 +121,10 @@ export default class DatePickerDialog extends Component{
                   />
                   <View style={{flexDirection: 'row'}}>
                     <TouchableHighlight style={{flex:1}} onPress={this.cancel.bind(this)} underlayColor={"#57D4E8"}>
-                      <View style={{}}><Text style={styles.buttonTextStyle}>CANCEL</Text></View>
+                      <View style={{}}><Text style={styles.buttonTextStyle}>{this.props.cancelLabel}</Text></View>
                     </TouchableHighlight>
                     <TouchableHighlight style={{flex:1}} onPress={this.ok.bind(this)} underlayColor={"#57D4E8"}>
-                      <View style={{}}><Text style={styles.buttonTextStyle}>OK</Text></View>
+                      <View style={{}}><Text style={styles.buttonTextStyle}>{this.props.okLabel}</Text></View>
                     </TouchableHighlight>
                   </View>
                 </View>


### PR DESCRIPTION
OK and Cancel button labels of the Dialog on iOS should be changed through `okLabel` and `cancelLabel` props.