### PR TITLE
fix deprecation for react v15.5.0: https://reactjs.org/blog/2017/04/0…

### DIFF
--- a/lib/datepicker/DatePickerDialog.android.js
+++ b/lib/datepicker/DatePickerDialog.android.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   View,
   DatePickerAndroid,

--- a/lib/datepicker/DatePickerDialog.ios.js
+++ b/lib/datepicker/DatePickerDialog.ios.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   View,
   DatePickerIOS,
@@ -47,7 +48,7 @@ export default class DatePickerDialog extends Component{
  *   * `date` (`Date` object or timestamp in milliseconds) - date to show by default
  *   * `minDate` (`Date` or timestamp in milliseconds) - minimum date that can be selected
  *   * `maxDate` (`Date` object or timestamp in milliseconds) - minimum date that can be selected
- * 
+ *
  */
   open(options: Object){
     this.setState({


### PR DESCRIPTION
The new React Native v15.5.0 put in warnings for code that will break in v16. One of it is the usage of PropTypes which will then be put inside 'prop-types' package

This pull request import the package correctly for ReactNative v15.5.0 onwards

See:
https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes